### PR TITLE
Include traceback when logging exception

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changelog
 - Avoid using deprecated zope.app.appsetup and use instead zope.processlifetime.
   [gforcada]
 
+- Include traceback when logging exception
+
 0.6.0 (2021-05-12)
 ------------------
 

--- a/haufe/requestmonitoring/monitor.py
+++ b/haufe/requestmonitoring/monitor.py
@@ -100,11 +100,11 @@ class _Monitor:
                     try:
                         handler(monitorTime, pending)
                     except Exception as e:  # noqa: E722
-                        log.error(
+                        log.exception(
                                 'handler exception for {0}: {1}'.format(  # noqa: E501
                                 handler.name, e))
         except:  # noqa: E722
-            log.error(
+            log.exception(
                 'monitor thread died with exception')
 
 


### PR DESCRIPTION
before, logs contain only:

```
2024-11-01 16:20:54,000 ERROR RequestMonitor handler exception for dumper: 'str' object has no attribute 'decode'
```

after this change we see the traceback of the original problem